### PR TITLE
feat: Add admin mode with teacher login (closes #5)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,12 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+import json
 import os
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +20,14 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from JSON file
+teachers_file = os.path.join(current_dir, "teachers.json")
+with open(teachers_file, "r") as f:
+    teachers_data = json.load(f)
+
+# Simple token store: token -> username
+active_tokens: dict[str, str] = {}
 
 # In-memory activity database
 activities = {
@@ -78,9 +88,39 @@ activities = {
 }
 
 
+def verify_token(authorization: str | None) -> str:
+    """Verify the Bearer token and return the username."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    token = authorization.split(" ", 1)[1]
+    if token not in active_tokens:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    return active_tokens[token]
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
+
+
+@app.post("/login")
+def login(username: str, password: str):
+    """Authenticate a teacher and return a session token."""
+    for teacher in teachers_data["teachers"]:
+        if teacher["username"] == username and teacher["password"] == password:
+            token = secrets.token_hex(16)
+            active_tokens[token] = username
+            return {"token": token, "username": username}
+    raise HTTPException(status_code=401, detail="Invalid username or password")
+
+
+@app.post("/logout")
+def logout(authorization: str | None = Header(default=None)):
+    """Log out by invalidating the session token."""
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization.split(" ", 1)[1]
+        active_tokens.pop(token, None)
+    return {"message": "Logged out"}
 
 
 @app.get("/activities")
@@ -89,8 +129,10 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, authorization: str | None = Header(default=None)):
+    """Sign up a student for an activity (teacher login required)"""
+    verify_token(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +153,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, authorization: str | None = Header(default=None)):
+    """Unregister a student from an activity (teacher login required)"""
+    verify_token(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,7 +2,117 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const signupContainer = document.getElementById("signup-container");
   const messageDiv = document.getElementById("message");
+
+  // Auth elements
+  const userIcon = document.getElementById("user-icon");
+  const userDropdown = document.getElementById("user-dropdown");
+  const loginSection = document.getElementById("login-section");
+  const loggedInSection = document.getElementById("logged-in-section");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginError = document.getElementById("login-error");
+  const loggedInUser = document.getElementById("logged-in-user");
+
+  // Session state
+  let authToken = sessionStorage.getItem("authToken") || null;
+  let loggedInUsername = sessionStorage.getItem("username") || null;
+
+  function isLoggedIn() {
+    return !!authToken;
+  }
+
+  function updateUIForAuth() {
+    if (isLoggedIn()) {
+      loginSection.classList.add("hidden");
+      loggedInSection.classList.remove("hidden");
+      loggedInUser.textContent = loggedInUsername;
+      signupContainer.classList.remove("hidden");
+      userIcon.textContent = "👤";
+    } else {
+      loginSection.classList.remove("hidden");
+      loggedInSection.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+      userIcon.textContent = "👤";
+    }
+    // Re-render activities to show/hide delete buttons
+    fetchActivities();
+  }
+
+  // Toggle dropdown
+  userIcon.addEventListener("click", (e) => {
+    e.stopPropagation();
+    userDropdown.classList.toggle("hidden");
+  });
+
+  // Close dropdown when clicking outside
+  document.addEventListener("click", (e) => {
+    if (!userDropdown.contains(e.target) && e.target !== userIcon) {
+      userDropdown.classList.add("hidden");
+    }
+  });
+
+  // Login handler
+  loginBtn.addEventListener("click", async () => {
+    const username = document.getElementById("login-username").value.trim();
+    const password = document.getElementById("login-password").value.trim();
+    if (!username || !password) {
+      loginError.textContent = "Please enter both username and password.";
+      loginError.classList.remove("hidden");
+      return;
+    }
+    try {
+      const response = await fetch(
+        `/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const result = await response.json();
+      if (response.ok) {
+        authToken = result.token;
+        loggedInUsername = result.username;
+        sessionStorage.setItem("authToken", authToken);
+        sessionStorage.setItem("username", loggedInUsername);
+        loginError.classList.add("hidden");
+        document.getElementById("login-username").value = "";
+        document.getElementById("login-password").value = "";
+        userDropdown.classList.add("hidden");
+        updateUIForAuth();
+      } else {
+        loginError.textContent = result.detail || "Login failed.";
+        loginError.classList.remove("hidden");
+      }
+    } catch (err) {
+      loginError.textContent = "Login request failed.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Logout handler
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+    } catch (_) {
+      // Ignore errors on logout
+    }
+    authToken = null;
+    loggedInUsername = null;
+    sessionStorage.removeItem("authToken");
+    sessionStorage.removeItem("username");
+    userDropdown.classList.add("hidden");
+    updateUIForAuth();
+  });
+
+  // Function to get auth headers
+  function authHeaders() {
+    if (authToken) {
+      return { Authorization: `Bearer ${authToken}` };
+    }
+    return {};
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +122,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      // Clear and rebuild select options
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -21,21 +133,24 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
+        // Create participants HTML — only show delete buttons when logged in
+        let participantsHTML;
+        if (details.participants.length > 0) {
+          const listItems = details.participants
+            .map((email) => {
+              const deleteBtn = isLoggedIn()
+                ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                : "";
+              return `<li><span class="participant-email">${email}</span>${deleteBtn}</li>`;
+            })
+            .join("");
+          participantsHTML = `<div class="participants-section">
               <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
-            : `<p><em>No participants yet</em></p>`;
+              <ul class="participants-list">${listItems}</ul>
+            </div>`;
+        } else {
+          participantsHTML = `<p><em>No participants yet</em></p>`;
+        }
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
@@ -56,7 +171,7 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners to delete buttons (only present when logged in)
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
@@ -80,6 +195,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeaders(),
         }
       );
 
@@ -88,8 +204,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -97,8 +211,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);
@@ -124,6 +236,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeaders(),
         }
       );
 
@@ -133,8 +246,6 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -142,8 +253,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);
@@ -155,6 +264,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  // Initialize app
-  fetchActivities();
+  // Initialize — set UI based on session and load activities
+  updateUIForAuth();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,22 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="user-menu">
+        <button id="user-icon" title="Teacher Login">👤</button>
+        <div id="user-dropdown" class="hidden">
+          <div id="login-section">
+            <h4>Teacher Login</h4>
+            <input type="text" id="login-username" placeholder="Username" />
+            <input type="password" id="login-password" placeholder="Password" />
+            <button id="login-btn">Log In</button>
+            <p id="login-error" class="hidden"></p>
+          </div>
+          <div id="logged-in-section" class="hidden">
+            <p>Logged in as <strong id="logged-in-user"></strong></p>
+            <button id="logout-btn">Log Out</button>
+          </div>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -21,7 +37,7 @@
         </div>
       </section>
 
-      <section id="signup-container">
+      <section id="signup-container" class="hidden">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,94 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+/* User menu / login dropdown */
+#user-menu {
+  position: absolute;
+  top: 15px;
+  right: 20px;
+}
+
+#user-icon {
+  background: rgba(255, 255, 255, 0.15);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  color: white;
+  font-size: 22px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background 0.2s;
+}
+
+#user-icon:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+#user-dropdown {
+  position: absolute;
+  top: 52px;
+  right: 0;
+  background: white;
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  padding: 18px;
+  width: 240px;
+  z-index: 100;
+  text-align: left;
+}
+
+#user-dropdown h4 {
+  margin-bottom: 12px;
+  color: #1a237e;
+}
+
+#user-dropdown input {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+#login-btn,
+#logout-btn {
+  width: 100%;
+  padding: 8px;
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+#logout-btn {
+  background-color: #c62828;
+}
+
+#logout-btn:hover {
+  background-color: #e53935;
+}
+
+#login-error {
+  color: #c62828;
+  font-size: 13px;
+  margin-top: 6px;
+}
+
+#logged-in-section p {
+  margin-bottom: 10px;
+  font-size: 14px;
 }
 
 main {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "admin",
+      "password": "admin123"
+    },
+    {
+      "username": "mrsmith",
+      "password": "teacher456"
+    },
+    {
+      "username": "msjohnson",
+      "password": "teacher789"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements **Issue #5 — Admin Mode** to prevent students from removing each other from activities.

## Changes

### Backend (`src/app.py`)
- **`POST /login`** — authenticates a teacher by username/password and returns a session token
- **`POST /logout`** — invalidates the session token
- **`POST /signup`** and **`DELETE /unregister`** now require a valid `Authorization: Bearer <token>` header (returns 401 otherwise)
- **`GET /activities`** remains public — students can still view everything

### New file (`src/teachers.json`)
- JSON file storing teacher usernames and passwords, checked by the backend
- Ships with 3 default accounts: `admin`, `mrsmith`, `msjohnson`

### Frontend (`src/static/`)
- 👤 User icon in the top-right header corner opens a login dropdown
- After login, shows "Logged in as **username**" with a Log Out button
- The signup form is **hidden** for unauthenticated users
- The ❌ unregister buttons next to participants **only appear when logged in**
- Token persists in `sessionStorage` for the browser tab lifetime

## How to test
1. Open the app — activities are visible but signup form and delete buttons are hidden
2. Click the 👤 icon → log in with `admin` / `admin123`
3. Signup form and delete buttons now appear
4. Log out → controls are hidden again

Closes #5